### PR TITLE
Update deps. Idiomatic Pedestal changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # geheimtur-demo
 
-an application to demonstrate [geheimtur] [1] functionality.
+an application to demonstrate [geheimtur][1] functionality.
 
-[Live Demo] [2]
+[Live Demo][2]
 
 ## Getting Started
 

--- a/project.clj
+++ b/project.clj
@@ -1,27 +1,19 @@
 (defproject geheimtur-demo "0.0.1-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "Geheimtür Demo Application"
+  :description "Geheimtür Demo Application"
+  :url "https://github.com/propan/geheimtur-demo"
   :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [io.pedestal/pedestal.service "0.4.0"]
-                 [io.pedestal/pedestal.service-tools "0.4.0"]
-                 [io.pedestal/pedestal.jetty "0.4.0"]
-                 [hiccup "1.0.4"]
-                 [geheimtur "0.3.0"]
-                 [cheshire "5.2.0"]]
+            :url  "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [io.pedestal/pedestal.service "0.5.2"]
+                 [io.pedestal/pedestal.jetty "0.5.2"]
+                 [hiccup "1.0.5"]
+                 [geheimtur "0.3.1"]
+                 [cheshire "5.7.0"]
+                 [ch.qos.logback/logback-classic "1.1.8" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "1.7.22"]
+                 [org.slf4j/jcl-over-slf4j "1.7.22"]
+                 [org.slf4j/log4j-over-slf4j "1.7.22"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :aliases {"run-dev" ["trampoline" "run" "-m" "geheimtur-demo.server/run-dev"]}
-  :repl-options  {:init-ns user
-                  :init (try
-                          (use 'io.pedestal.service-tools.dev)
-                          (require 'geheimtur-demo.service)
-                          ;; Nasty trick to get around being unable to reference non-clojure.core symbols in :init
-                          (eval '(init geheimtur-demo.service/service #'geheimtur-demo.service/routes))
-                          (catch Throwable t
-                            (println "ERROR: There was a problem loading io.pedestal.service-tools.dev")
-                            (clojure.stacktrace/print-stack-trace t)
-                            (println)))
-                  :welcome (println "Welcome to pedestal-service! Run (tools-help) to see a list of useful functions.")}
   :main ^{:skip-aot true} geheimtur-demo.server)


### PR DESCRIPTION
- Prefer [tabular routes](http://pedestal.io/guides/defining-routes#_a_note_about_routing_syntax).
- Prefer the interceptor API over the interceptor helpers.
- Form params now have their keys keywordized.
- `io.pedestal.service-tools.dev` has been removed.